### PR TITLE
Add minimal Use Case Diagram Generator skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Use-Case-Generator
+# Use Case Diagram Generator
+
+Minimal stateless application for generating use case diagrams via OpenAI.
+
+## Backend
+
+```bash
+cd backend
+poetry install
+poetry run uvicorn main:app --reload
+```
+
+Environment variables are stored in `.env` (set `OPENAI_API_KEY`).
+
+## Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The application uses React and Vite. The diagram is rendered inside an iframe
+using the diagrams.net embed script.
+

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-api-key

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from dotenv import load_dotenv
+import os
+import openai
+
+load_dotenv()
+
+app = FastAPI()
+
+class DiagramRequest(BaseModel):
+    description: str
+
+class DiagramResponse(BaseModel):
+    xml: str
+
+@app.post("/generate-diagram", response_model=DiagramResponse)
+async def generate_diagram(data: DiagramRequest):
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    if not openai.api_key:
+        raise HTTPException(status_code=500, detail="API key not configured")
+
+    messages = [
+        {"role": "system", "content": "Ты — помощник, генерируешь draw.io XML для Use Case-диаграммы."},
+        {"role": "user", "content": data.description},
+    ]
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=messages,
+            temperature=0,
+        )
+        xml = response["choices"][0]["message"]["content"].strip()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"xml": xml}
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "use-case-generator"
+version = "0.1.0"
+description = "Use Case Diagram Generator backend"
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "*"
+uvicorn = {extras = ["standard"], version="*"}
+openai = "*"
+python-dotenv = "*"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "use-case-diagram-generator",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Use Case Diagram Generator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+    <script src="https://embed.diagrams.net/js/embed.min.js"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,65 @@
+import { useState, useRef } from 'react';
+import './App.css';
+
+function App() {
+  const [description, setDescription] = useState('');
+  const iframeRef = useRef(null);
+  const xmlRef = useRef('');
+
+  const generate = async () => {
+    const res = await fetch('/generate-diagram', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description }),
+    });
+    const data = await res.json();
+    xmlRef.current = data.xml;
+    iframeRef.current?.contentWindow.postMessage({ action: 'load', xml: data.xml }, '*');
+  };
+
+  const downloadXml = () => {
+    const blob = new Blob([xmlRef.current], { type: 'application/xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'usecase-diagram.xml';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportPng = () => {
+    iframeRef.current?.contentWindow.postMessage({ action: 'export', format: 'png' }, '*');
+  };
+
+  window.addEventListener('message', (event) => {
+    if (event.data?.event === 'export') {
+      const a = document.createElement('a');
+      a.href = event.data.dataUrl;
+      a.download = 'usecase-diagram.png';
+      a.click();
+    }
+  });
+
+  return (
+    <div>
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Describe your use cases"
+        rows={4}
+        style={{ width: '100%' }}
+      />
+      <button onClick={generate}>Generate</button>
+      <button onClick={downloadXml}>Download XML</button>
+      <button onClick={exportPng}>Download PNG</button>
+      <iframe
+        ref={iframeRef}
+        title="diagram"
+        style={{ width: '100%', height: '500px', border: '1px solid #ccc', marginTop: '1rem' }}
+        src="https://embed.diagrams.net/?embed=1&ui=min&proto=json"
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold backend with FastAPI endpoint to call OpenAI API
- add Poetry config and `.env` placeholder
- scaffold frontend React app using Vite
- basic UI for entering description and rendering diagram via diagrams.net
- document setup steps in README

## Testing
- `poetry install` *(fails: could not connect to pypi.org)*
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6876a20bedd8832a8b0929aa5cdebd39